### PR TITLE
Fixed failure in :app:compileDebugJava "error: android.test.ActivityInst...

### DIFF
--- a/app/src/debug/java/com/circle/testexample/InjectedBaseActivityTest.java
+++ b/app/src/debug/java/com/circle/testexample/InjectedBaseActivityTest.java
@@ -7,7 +7,7 @@ import com.circle.testexample.ui.BaseActivity;
 
 import javax.inject.Inject;
 
-public class InjectedBaseActivityTest extends ActivityInstrumentationTestCase2 {
+public class InjectedBaseActivityTest extends ActivityInstrumentationTestCase2<BaseActivity> {
     @Inject
     Api mockApi;
 


### PR DESCRIPTION
Fixed failure in :app:compileDebugJava "error: android.test.ActivityInstrumentationTestCase2 has type parameters, cannot members inject the raw type."

Now it works for me, so I'd like to share this in case others are having the same problem.
