### PR TITLE
Updated Dagger Graph naming policy

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     compile 'io.reactivex:rxandroid:0.23.0'
 
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile 'com.google.dagger:dagger:2.0-SNAPSHOT'
-    apt 'com.google.dagger:dagger-compiler:2.0-SNAPSHOT'
+    compile 'com.google.dagger:dagger:2.1-SNAPSHOT'
+    apt 'com.google.dagger:dagger-compiler:2.1-SNAPSHOT'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
     // adds the @Generated annoation that Android lacks

--- a/app/src/debug/java/com/circle/testexample/Graph.java
+++ b/app/src/debug/java/com/circle/testexample/Graph.java
@@ -16,7 +16,7 @@ public interface Graph {
 
     public final static class Initializer {
         public static Graph init(boolean mockMode) {
-            return Dagger_Graph.builder()
+            return DaggerGraph.builder()
                     .debugDataModule(new DebugDataModule(mockMode))
                     .build();
         }


### PR DESCRIPTION
Previous _2.0-SNAPSHOT_ was not being found, and they changed the naming policy in the new _2.1-SNAPSHOT_. So, instead of `Dagger_Graph` now the class is called `DaggerGraph`.
